### PR TITLE
Bug fix - update name of dataset referenced by report widget

### DIFF
--- a/force-app/main/default/waveTemplates/DeveloperCarbonDashboard/dashboards/Carbon_Emissions.json
+++ b/force-app/main/default/waveTemplates/DeveloperCarbonDashboard/dashboards/Carbon_Emissions.json
@@ -2086,7 +2086,7 @@
         "broadcastFacet" : true,
         "datasets" : [
           {
-            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.Name}"
+            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
           }
         ],
         "isGlobal" : false,
@@ -2202,7 +2202,7 @@
         "broadcastFacet" : true,
         "datasets" : [
           {
-            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.Name}"
+            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
           }
         ],
         "isGlobal" : false,
@@ -2372,7 +2372,7 @@
         "broadcastFacet" : true,
         "datasets" : [
           {
-            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.Name}"
+            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
           }
         ],
         "isGlobal" : false,
@@ -2816,7 +2816,7 @@
         "broadcastFacet" : true,
         "datasets" : [
           {
-            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.Name}"
+            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
           }
         ],
         "isGlobal" : false,
@@ -3552,7 +3552,7 @@
         "broadcastFacet" : true,
         "datasets" : [
           {
-            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.Name}"
+            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
           }
         ],
         "isGlobal" : false,
@@ -3651,7 +3651,7 @@
         "broadcastFacet" : true,
         "datasets" : [
           {
-            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
+            "name" : "${Apps.AdminAnalytics.Datasets.ReportWithUsers.FullyQualifiedName}"
           }
         ],
         "isGlobal" : false,
@@ -3688,7 +3688,7 @@
                 "all"
               ],
               "joins" : [ ],
-              "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
+              "name" : "${Apps.AdminAnalytics.Datasets.ReportWithUsers.FullyQualifiedName}"
             },
             {
               "columns" : [
@@ -3713,7 +3713,7 @@
                 "all"
               ],
               "joins" : [ ],
-              "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
+              "name" : "${Apps.AdminAnalytics.Datasets.ReportWithUsers.FullyQualifiedName}"
             },
             {
               "columns" : [
@@ -3738,7 +3738,7 @@
                 "all"
               ],
               "joins" : [ ],
-              "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
+              "name" : "${Apps.AdminAnalytics.Datasets.ReportWithUsers.FullyQualifiedName}"
             },
             {
               "columns" : [
@@ -4132,7 +4132,7 @@
         "broadcastFacet" : true,
         "datasets" : [
           {
-            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
+            "name" : "${Apps.AdminAnalytics.Datasets.ReportWithUsers.FullyQualifiedName}"
           }
         ],
         "isGlobal" : false,
@@ -4151,7 +4151,7 @@
           ],
           "rowTotals" : [ ],
           "sourceFilters" : {
-            "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}" : {
+            "${Apps.AdminAnalytics.Datasets.ReportWithUsers.FullyQualifiedName}" : {
               "filters" : [
                 [
                   "RUN_TIME",
@@ -4190,7 +4190,7 @@
               "filters" : [ ],
               "groups" : [ ],
               "joins" : [ ],
-              "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
+              "name" : "${Apps.AdminAnalytics.Datasets.ReportWithUsers.FullyQualifiedName}"
             }
           ]
         },
@@ -4480,7 +4480,7 @@
         "broadcastFacet" : true,
         "datasets" : [
           {
-            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}"
+            "name" : "${Apps.AdminAnalytics.Datasets.ReportWithUsers.FullyQualifiedName}"
           }
         ],
         "isGlobal" : false,

--- a/force-app/main/default/waveTemplates/DeveloperCarbonDashboard/recipes/CarbonEmissionsApex.json
+++ b/force-app/main/default/waveTemplates/DeveloperCarbonDashboard/recipes/CarbonEmissionsApex.json
@@ -1294,7 +1294,7 @@
           "dataset" : {
             "type" : "analyticsDataset",
             "label" : "Aggregated Carbon Emissions",
-            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.Name}",
+            "name" : "${App.Datasets.AggregatedCarbonEmissions_tp.FullyQualifiedName}",
             "folderName" : "${App.Folder.FullyQualifiedName}"
           },
           "measuresToCurrencies" : [ ]

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "Developer Carbon Dashboard",
-      "versionName": "ver 0.7",
-      "versionNumber": "0.7.0.NEXT",
+      "versionName": "ver 0.10",
+      "versionNumber": "0.10.0.NEXT",
       "versionDescription": "The latest released version of the Developer Carbon Dashboard. It surfaces insights into which parts of an org are generating the most emissions so they can be improved.",
       "ancestorVersion": "HIGHEST"
     }
@@ -20,6 +20,9 @@
     "Developer Carbon Dashboard@0.3.0-1": "04tHn000000ybKzIAI",
     "Developer Carbon Dashboard@0.4.0-1": "04tHn000000ybo8IAA",
     "Developer Carbon Dashboard@0.5.0-1": "04tHn000000jxbLIAQ",
-    "Developer Carbon Dashboard@0.6.0-1": "04tHn000000jxbQIAQ"
+    "Developer Carbon Dashboard@0.6.0-1": "04tHn000000jxbQIAQ",
+    "Developer Carbon Dashboard@0.8.0-1": "04tHn000000k8HpIAI",
+    "Developer Carbon Dashboard@0.9.0-1": "04tHn000000k8HuIAI",
+    "Developer Carbon Dashboard@0.10.0-1": "04tHn000000k8HzIAI"
   }
 }


### PR DESCRIPTION
There were 2 types of updates here:

1. Report widget: Update the dataset being referenced from "AggregatedCarbonEmissions_tp" to "ReportWithUsers" and update path to this file
2. Other: On some correct references to the "AggregatedCarbonEmissions_tp" dataset, update references to "Name" to use "FullyQualifiedName" instead to handle namespace without erroring.